### PR TITLE
Add clone instruction in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ to download it for your platform.
 
 ## Build
 
+To build from source, clone the repository:
+```
+git clone https://github.com/whitemech/lydia.git --recursive
+cd lydia
+```
+
 To build:
 
 ```bash


### PR DESCRIPTION
Add instruction about how to clone the project locally. Importantly, it includes the `--recursive` flag in order to clone the `third_party` submodules.