### PR TITLE
Add tests on logger

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/spdlog"]
 	path = third_party/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "third_party/fmt"]
+	path = third_party/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,19 @@
+#
+# This file is part of Lydia.
+#
+# Lydia is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lydia is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
+
 # CMake build : global project
 
 cmake_minimum_required(VERSION 3.13)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,18 @@
-# Distributed under the MIT License (See accompanying file /LICENSE )
+#
+# This file is part of Lydia.
+#
+# Lydia is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lydia is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
 
 # CMake build : main application
 

--- a/app/test/CMakeLists.txt
+++ b/app/test/CMakeLists.txt
@@ -1,4 +1,18 @@
-# Distributed under the MIT License (See accompanying file /LICENSE )
+#
+# This file is part of Lydia.
+#
+# Lydia is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lydia is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
 
 # CMake build : main application test
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,19 @@
-# Distributed under the MIT License (See accompanying file /LICENSE )
+#
+# This file is part of Lydia.
+#
+# Lydia is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lydia is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
+
 
 # CMake build : library
 

--- a/lib/include/logger.hpp
+++ b/lib/include/logger.hpp
@@ -15,3 +15,82 @@
  * You should have received a copy of the GNU General Public License
  * along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
  */
+#define SPDLOG_FMT_EXTERNAL
+#define FMT_HEADER_ONLY
+#include <spdlog/fmt/ostr.h>
+#include <spdlog/spdlog.h>
+#include <string>
+
+namespace whitemech::lydia {
+
+    enum class LogLevel {
+        info = spdlog::level::level_enum::info,
+        trace = spdlog::level::level_enum::trace,
+        debug = spdlog::level::level_enum::debug,
+        error = spdlog::level::level_enum::err
+    };
+
+    class Logger {
+    public:
+        explicit Logger(std::string section);
+        static constexpr const char * const logger_name = "whitemech::lydia::logger";
+        auto section() const noexcept { return section_; }
+
+        template<typename Arg1, typename... Args>
+        void log(const LogLevel level, const char *fmt, const Arg1 &arg1,
+                 const Args &... args) {
+            auto new_fmt = "[{}] " + std::string(fmt);
+
+            internal_logger_->log(static_cast<spdlog::level::level_enum>(level),
+                                  new_fmt.c_str(), section(), arg1, args...);
+        }
+
+        template<typename Arg1, typename... Args>
+        void info(const char *fmt, const Arg1 &arg1, const Args &... args) {
+            log(LogLevel::info, fmt, arg1, args...);
+        }
+
+        template<typename Arg1>
+        void info(const Arg1 &arg1) {
+            info("{}", arg1);
+        }
+
+        template<typename Arg1, typename... Args>
+        void debug(const char *fmt, const Arg1 &arg1, const Args &... args) {
+            log(LogLevel::debug, fmt, arg1, args...);
+        }
+
+        template<typename Arg1>
+        void debug(const Arg1 &arg1) {
+            debug("{}", arg1);
+        }
+
+        template<typename Arg1, typename... Args>
+        void trace(const char *fmt, const Arg1 &arg1, const Args &... args) {
+            log(LogLevel::trace, fmt, arg1, args...);
+        }
+
+        template<typename Arg1>
+        void trace(const Arg1 &arg1) {
+            trace("{}", arg1);
+        }
+
+        template<typename Arg1, typename... Args>
+        void error(const char *fmt, const Arg1 &arg1, const Args &... args) {
+            log(LogLevel::error, fmt, arg1, args...);
+        }
+
+        template<typename Arg1>
+        void error(const Arg1 &arg1) {
+            error("{}", arg1);
+        }
+
+        static void level(const LogLevel level) noexcept {
+            spdlog::set_level(static_cast<spdlog::level::level_enum>(level));
+        }
+
+    private:
+        std::string section_{""};
+        std::shared_ptr<spdlog::logger> internal_logger_{nullptr};
+    };
+}

--- a/lib/src/logger.cpp
+++ b/lib/src/logger.cpp
@@ -14,3 +14,45 @@
  * You should have received a copy of the GNU General Public License
  * along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "logger.hpp"
+#include <spdlog/sinks/dist_sink.h>
+
+#ifdef _WIN32
+#include <spdlog/sinks/wincolor_sink.h>
+#else
+#include <spdlog/sinks/ansicolor_sink.h>
+#endif
+
+#if defined(_DEBUG) && defined(_MSC_VER)
+#include <spdlog/sinks/msvc_sink.h>
+#endif  // _DEBUG && _MSC_VER
+
+namespace whitemech::lydia {
+
+    auto create_spdlog(std::string logger_name) {
+#ifdef _WIN32
+        auto color_sink = std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>();
+#else
+        auto color_sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
+#endif
+        auto dist_sink = std::make_shared<spdlog::sinks::dist_sink_st>();
+        dist_sink->add_sink(color_sink);
+#if defined(_DEBUG) && defined(_MSC_VER)
+        auto debug_sink = std::make_shared<spdlog::sinks::msvc_sink_st>();
+    dist_sink->add_sink(debug_sink);
+#endif  // _DEBUG && _MSC_VER
+        auto logger_ = std::make_shared<spdlog::logger>(logger_name, dist_sink);
+        return logger_;
+    }
+
+    Logger::Logger(std::string section) : section_{std::move(section)} {
+        std::string log_name{whitemech::lydia::Logger::logger_name};
+        internal_logger_ = spdlog::get(log_name);
+
+        if (internal_logger_ == nullptr) {
+            internal_logger_ = create_spdlog(logger_name);
+            spdlog::register_logger(internal_logger_);
+        }
+    }
+
+}  // namespace whitemech::lydia

--- a/lib/test/CMakeLists.txt
+++ b/lib/test/CMakeLists.txt
@@ -1,4 +1,18 @@
-# Distributed under the MIT License (See accompanying file /LICENSE )
+#
+# This file is part of Lydia.
+#
+# Lydia is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lydia is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
 
 # CMake build : library tests
 

--- a/lib/test/src/logger_test.cpp
+++ b/lib/test/src/logger_test.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Distributed under the MIT License (See accompanying file /LICENSE )
+ */
+#include "logger.hpp"
+#include "catch.hpp"
+
+namespace whitemech::lydia::Test {
+
+    class Person {
+    public:
+        Person(const std::string &name, const unsigned int &age) noexcept
+                : name_{name}, age_{age} {}
+
+        friend std::ostream &operator<<(std::ostream &stream, const Person &object) {
+            stream << "name: " << object.name_ << " age: " << object.age_;
+            return stream;
+        }
+
+    private:
+        std::string name_{""};
+        unsigned int age_{0};
+    };
+
+    TEST_CASE("logger work as expected", "[logger]") {
+        Logger log("logger test");
+
+        SECTION("the section is correct") { REQUIRE(log.section() == "logger test"); }
+
+        SECTION("we could set log level") {
+            Logger::level(LogLevel::trace);
+            CHECK(true);
+        }
+
+        SECTION("we could info") {
+            log.info("this is a {} message", "info");
+            REQUIRE(true);
+        }
+
+        SECTION("we could trace") {
+            log.trace("this is a {} message", "trace");
+            REQUIRE(true);
+        }
+
+        SECTION("we could debug") {
+            log.debug("this is a {} message", "debug");
+            REQUIRE(true);
+        }
+
+        SECTION("we could error") {
+            log.error("this is a {} message", "error");
+            REQUIRE(true);
+        }
+
+        SECTION("we could simple logging info") {
+            log.info("this is simple info logging");
+            REQUIRE(true);
+        }
+
+        SECTION("we could simple logging trace") {
+            log.trace("this is simple trace logging");
+            REQUIRE(true);
+        }
+
+        SECTION("we could simple logging debug") {
+            log.debug("this is simple debug logging");
+            REQUIRE(true);
+        }
+
+        SECTION("we could simple logging error") {
+            log.error("this is simple error logging");
+            REQUIRE(true);
+        }
+
+        SECTION("we could logging with level as arg") {
+            log.log(LogLevel::info, "this is simple logging with {} as arg", "level");
+            REQUIRE(true);
+        }
+
+        Person person{"test", 20};
+
+        SECTION("we could info objects") {
+            log.info(person);
+            REQUIRE(true);
+        }
+
+        SECTION("we could trace objects") {
+            log.trace(person);
+            REQUIRE(true);
+        }
+
+        SECTION("we could debug objects") {
+            log.debug(person);
+            REQUIRE(true);
+        }SECTION("we could error objects") {
+            log.error(person);
+            REQUIRE(true);
+        }
+    }
+
+}  // namespace whitemech

--- a/lib/test/src/logger_test.cpp
+++ b/lib/test/src/logger_test.cpp
@@ -1,5 +1,18 @@
 /*
- *  Distributed under the MIT License (See accompanying file /LICENSE )
+ * This file is part of Lydia.
+ *
+ * Lydia is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lydia is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Lydia.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "logger.hpp"
 #include "catch.hpp"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -22,8 +22,17 @@ set (SPDLOG_INCLUDE_PATH "${SPDLOG_MODULE_PATH}/include")
 
 # -------------------------------------------------------------------------
 
+# -------------------------------------------------------------------------
+# fmt
+
+#configure directories
+set (FMT_MODULE_PATH "${THIRD_PARTY_MODULE_PATH}/fmt")
+set (FMT_INCLUDE_PATH "${FMT_MODULE_PATH}/include")
+
+# -------------------------------------------------------------------------
+
 #set variables
-set (THIRD_PARTY_INCLUDE_PATH  ${SPDLOG_INCLUDE_PATH})
+set (THIRD_PARTY_INCLUDE_PATH  ${FMT_INCLUDE_PATH} ${SPDLOG_INCLUDE_PATH})
 
 #set variables for tests
 set (TEST_THIRD_PARTY_INCLUDE_PATH  ${CATCH_INCLUDE_PATH})


### PR DESCRIPTION
This PR adds tests on logger.

That needed to add the dependency 'fmt' as external and not included in 'spdlog' due to a weird linking error...