### PR TITLE
fix names and github references of authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,9 +2,9 @@
 
 This is the list of Lydia authors and contributors.
 
-* [Antonio DI Stasio](https://github.com/antoniodistasio) <[distasio@diag.uniroma1.it](mailto:distasio@diag.uniroma1.it)>
+* [Antonio Di Stasio](https://github.com/antoniodistasio) <[distasio@diag.uniroma1.it](mailto:distasio@diag.uniroma1.it)>
 * [Marco Favorito](https://github.com/marcofavorito) <[favorito@diag.uniroma1.it](mailto:favorito@diag.uniroma1.it)>
-* [Francesco Fuggitti](https://github.com/Francesco17) <[fuggitti@diag.uniroma1.it](mailto:fuggitti@diag.uniroma1.it)>
+* [Francesco Fuggitti](https://github.com/francescofuggitti) <[fuggitti@diag.uniroma1.it](mailto:fuggitti@diag.uniroma1.it)>
 
 ## Contributors
 


### PR DESCRIPTION
This is a tiny PR..

I fixed Antonio's surname and Fuggitti's GitHub link on authors page