### PR TITLE
Add check to <rho*>phi if rho* is atomic until test

### DIFF
--- a/lib/include/lydia/to_dfa/strategies/compositional/base.hpp
+++ b/lib/include/lydia/to_dfa/strategies/compositional/base.hpp
@@ -86,6 +86,7 @@ private:
   DFA *current_formula_ = nullptr;
   bool is_diamond;
 
+  static bool is_atomic_until_test_(const RegExp &r);
   void test_free_star_(const StarRegExp &);
   void general_star_(const StarRegExp &);
 


### PR DESCRIPTION
Add check to <rho*>phi if rho* is atomic until test.

An atomic until test is a regular expression as follows:

```
(<prop>tt?; true)*
```

where `prop` is a propositional regex.

In that case, we can use the faster translation.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
