### PR TITLE
Fix bug in concatenation

### DIFF
--- a/lib/src/mona_ext/mona_ext_base.cpp
+++ b/lib/src/mona_ext/mona_ext_base.cpp
@@ -90,8 +90,7 @@ DFA* dfa_concatenate(DFA* a, DFA* b, int n, int* indices) {
     if (is_current_state_final) {
       for (const auto& p : b_initial_state_ougoing_transitions) {
         std::tie(next_state, next_guard) = p;
-        int true_next_state =
-            next_state == b_initial_state ? i : next_state + ns2_offset;
+        int true_next_state = next_state + ns2_offset;
         dfaStoreException(true_next_state, next_guard.data());
       }
     }


### PR DESCRIPTION
Fix bug in concatenation.

in the concatenation operation, the next state of the concatenation transitions was shifted correctly, except when the next state was the initial state of the right operand. This exception has now been removed.

Formulae that didn't work were of the form e.g. `a U (b U c)`.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
