### PR TITLE
Fix Release LTLf-to-LDLf translation

### DIFF
--- a/lib/include/lydia/parser/ltlf/driver.cpp
+++ b/lib/include/lydia/parser/ltlf/driver.cpp
@@ -145,7 +145,7 @@ ldlf_ptr LTLfDriver::add_LTLfRelease(ldlf_ptr& lhs, ldlf_ptr& rhs) const {
   auto end = context->makeLdlfEnd();
   auto formula_or_end = context->makeLdlfOr({rhs, end});
   auto true_regex = context->makePropRegex(context->makeTrue());
-  auto formula_test = context->makeTestRegex(lhs);
+  auto formula_test = (context->makeTestRegex(context->makeLdlfNot(lhs)));
   auto seq_star =
       context->makeStarRegex(context->makeSeqRegex({formula_test, true_regex}));
   return context->makeLdlfBox(seq_star, formula_or_end);

--- a/lib/test/src/unit_tests/test_to_dfa/ltlf_tests.cpp
+++ b/lib/test/src/unit_tests/test_to_dfa/ltlf_tests.cpp
@@ -50,4 +50,27 @@ TEST_CASE("Translate a U b", "[translate][ltlf][basic]") {
   REQUIRE(verify(*automaton, {"01", "10"}, true));
 }
 
+TEST_CASE("Translate a R b", "[translate][ltlf][basic]") {
+  std::string formula_name = "a R b";
+  auto strategy_maker = GENERATE(strategies());
+  auto mgr = CUDD::Cudd();
+  auto strategy = strategy_maker(mgr);
+  auto automaton = to_dfa_from_formula_string<parsers::ltlf::LTLfDriver>(
+      formula_name, *strategy);
+  //  print_dfa(*automaton, formula_name);
+  REQUIRE(verify(*automaton, {}, true));
+  REQUIRE(verify(*automaton, {"00"}, false));
+  REQUIRE(verify(*automaton, {"01"}, false));
+  REQUIRE(verify(*automaton, {"10"}, true));
+  REQUIRE(verify(*automaton, {"11"}, true));
+  REQUIRE(verify(*automaton, {"11", "00"}, true));
+  REQUIRE(verify(*automaton, {"11", "01"}, true));
+  REQUIRE(verify(*automaton, {"11", "10"}, true));
+  REQUIRE(verify(*automaton, {"11", "11"}, true));
+  REQUIRE(verify(*automaton, {"00", "00"}, false));
+  REQUIRE(verify(*automaton, {"00", "01"}, false));
+  REQUIRE(verify(*automaton, {"00", "10"}, false));
+  REQUIRE(verify(*automaton, {"00", "11"}, false));
+}
+
 } // namespace whitemech::lydia::Test

--- a/lib/test/src/unit_tests/test_to_dfa/ltlf_tests.cpp
+++ b/lib/test/src/unit_tests/test_to_dfa/ltlf_tests.cpp
@@ -63,10 +63,10 @@ TEST_CASE("Translate a R b", "[translate][ltlf][basic]") {
   REQUIRE(verify(*automaton, {"01"}, false));
   REQUIRE(verify(*automaton, {"10"}, true));
   REQUIRE(verify(*automaton, {"11"}, true));
-  REQUIRE(verify(*automaton, {"11", "00"}, true));
-  REQUIRE(verify(*automaton, {"11", "01"}, true));
-  REQUIRE(verify(*automaton, {"11", "10"}, true));
-  REQUIRE(verify(*automaton, {"11", "11"}, true));
+  REQUIRE(verify(*automaton, {"10", "00"}, false));
+  REQUIRE(verify(*automaton, {"10", "01"}, false));
+  REQUIRE(verify(*automaton, {"10", "10"}, true));
+  REQUIRE(verify(*automaton, {"10", "11"}, true));
   REQUIRE(verify(*automaton, {"00", "00"}, false));
   REQUIRE(verify(*automaton, {"00", "01"}, false));
   REQUIRE(verify(*automaton, {"00", "10"}, false));


### PR DESCRIPTION
The Until formula in LDLf:

    a U b = <(a?;true)*>(<b>tt & !end)

How the Release formula should be translated:

    a R b = !(!a U !b) = !(<(!a?;true)*>(!<b>tt & !end)) = [(!a?;true)*](<b>tt | end)

How it was translated (wrongly) before this PR:

    a R b = [(a?;true)*](<b>tt | end)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
